### PR TITLE
Redirect /agenda2030 to pnud.carto.mx

### DIFF
--- a/assets/js/redirects.js
+++ b/assets/js/redirects.js
@@ -34,6 +34,10 @@ var list = [
       {
         name: 'catalogo',
         url: 'http://busca.datos.gob.mx/'
+      },
+      {
+        name: 'agenda2030',
+        url: 'http://pnud.carto.mx/'
       }
     ],
     dependency  = pathExist( window.location.pathname );


### PR DESCRIPTION
Hack rápido en lo que integramos herramienta PNUD a DGM.

How to test:
* Navega a http://localhost:4000/agenda2030 y debes ver la herramienta de PNUD

Aprueba @aniacalderon