### PR TITLE
Posts Excerpt

### DIFF
--- a/_includes/posts_container.html
+++ b/_includes/posts_container.html
@@ -10,7 +10,7 @@
                         <div class="col-lg-10 col-md-10 col-sm-10 col-xs-10">
                             <h5><a href="{{ post.permalink }}">{{ post.title }}</a></h5>
                             <p class="small">{{ post.date | date: '%d %B, %Y' }}</p>
-                            <p>{{ post.excerpt }}</p>
+                            <p>{{ post.content | strip_html | truncatewords: 50 }}</p>
                             <h6>{{ post.category_title }}</h6>
                         </div>
                     </div>
@@ -29,7 +29,7 @@
                         <div class="col-lg-9 col-md-9 col-sm-9 col-xs-9">
                             <h5><a href="{{ post.permalink }}">{{ post.title }}</a></h5>
                             <p class="small">{{ post.date | date: '%d %B, %Y' }}</p>
-                            <p>{{ post.excerpt }}</p>
+                            <p>{{ post.content | strip_html | truncatewords: 30 }}</p>
                             <h6>{{ post.category_title }}</h6>
                         </div>
                     </div>
@@ -52,7 +52,7 @@
                             <div class="col-lg-10 col-md-10 col-sm-10 col-xs-10">
                                 <h5><a href="{{ post.permalink }}">{{ post.title }}</a></h5>
                                 <p class="small">{{ post.date | date: '%d %B, %Y' }}</p>
-                                <p>{{ post.excerpt }}</p>
+                                <p>{{ post.content | strip_html | truncatewords: 50 }}</p>
                                 <h6>{{ post.category_title }}</h6>
                             </div>
                         </div>
@@ -70,7 +70,7 @@
                             <div class="col-lg-9 col-md-9 col-sm-9 col-xs-9">
                                 <h5><a href="{{ post.permalink }}">{{ post.title }}</a></h5>
                                 <p class="small">{{ post.date | date: '%d %B, %Y' }}</p>
-                                <p>{{ post.excerpt }}</p>
+                                <p>{{ post.content | strip_html | truncatewords: 30 }}</p>
                                 <h6>{{ post.category_title }}</h6>
                             </div>
                         </div>


### PR DESCRIPTION
Modified behavior to generate a post excerpt using the post content instead of an excerpt delimiter in the post

Closes #385 

<img width="1097" alt="screen shot 2015-09-28 at 15 23 22" src="https://cloud.githubusercontent.com/assets/1383865/10147779/b7471978-65f5-11e5-938f-bf8dacbe398a.png">
