### PR TITLE
Sections Description

### DIFF
--- a/_includes/apps_header.html
+++ b/_includes/apps_header.html
@@ -22,6 +22,9 @@
                 <p>{{ herramientas.size }} Web</p>
                 <p>{{ apps.size }} Móviles</p>
             </div>
+            <div class="col-lg-10 col-md-10 col-sm-6 col-xs-12">
+                <p>Interactúa con aplicaciones y visualizaciones para generar nuevo conocimiento.</p>
+            </div>
         </div>
     </div>
 </section>

--- a/_includes/impact_header.html
+++ b/_includes/impact_header.html
@@ -25,6 +25,9 @@
                 <p>{{ news.size }} Noticias</p>
                 <p>{{ avances.size }} Avances</p>
             </div>
+            <div class="col-lg-10 col-md-10 col-sm-6 col-xs-12">
+                <p>Descubre cómo los datos abiertos generan valor con historias de uso, noticias y eventos.</p>
+            </div>
         </div>
     </div>
 </section>


### PR DESCRIPTION
Added description to the `tools` and `impact` sections headers

Closes #384 

<img width="1421" alt="screen shot 2015-10-05 at 22 59 46" src="https://cloud.githubusercontent.com/assets/1383865/10299853/f82cca90-6bb4-11e5-92ee-6dd43bdc218b.png">
