### PR TITLE
Backgroud Blur

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -162,7 +162,7 @@ table.data > tbody > tr > td.ic-dataset img { width: 20px; }
     HIGHLIGHTS SECTION STYLES
 *********************************/
 #highlights                                 { padding: 15px 0; position: relative; }
-#highlights .background-image               { width: 100%; height: 100%; position: absolute; left: 0; top: 0; background: url(../assets/img/bg-banner.gif) no-repeat; background-size: cover; filter: blur(5px); }
+#highlights .background-image               { width: 100%; height: 100%; position: absolute; left: 0; top: 0; background: url(../assets/img/bg-banner.gif) no-repeat; background-size: cover; }
 #highlights .overlay                        { width: 100%; height: 100%; position: absolute; left: 0; top: 0; background-color: rgba(0,0,0,0.6); }
 #highlights h3                              { color: #fff; }
 #highlights h3 a                            { font-size: 21px; }


### PR DESCRIPTION
Removed blur from home page highlights section backgroud

Closes #587 

<img width="1428" alt="screen shot 2015-10-28 at 12 08 36" src="https://cloud.githubusercontent.com/assets/1383865/10798327/bfead4be-7d6c-11e5-90d9-34af729fedbb.png">
