### PR TITLE
Slider Breadcrumb

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@ title: datos.gob.mx
             <div class="item {% if forloop.first %}active{% endif %}">
                 <a href="{{ post.permalink }}" alt="{{ post.title }}"><img src="{{ "/assets/img/impacto/" | append: post.cover_photo | prepend: site.baseurl | prepend: site.url }}" alt="{{ post.title }}"></a>
                 <div class="carousel-caption">
-                    <p class="breadcrumb"><a href="#">Impacto</a> / <span>{{ post.category_title }}</span></p>
+                    <p class="breadcrumb"><a href="/impacto">Impacto</a> / <span>{{ post.sub_section }}</span></p>
                     <p><small>{{ post.author }}</small></p>
                     <h3><a href="{{ post.permalink }}" alt="{{ post.title }}">{{ post.title }}</a></h3>
                     <p class="hidden-sm hidden-xs"><a href="{{ post.permalink }}" alt="{{ post.title }}">{{ post.content | strip_html | truncatewords: 30 }}</a></p>


### PR DESCRIPTION
Modified slider breadcrumb to use the post `sub_section` instead of the `category`

Closes #586 

<img width="1008" alt="screen shot 2015-10-28 at 12 13 22" src="https://cloud.githubusercontent.com/assets/1383865/10798442/5335b8b0-7d6d-11e5-9fcb-fda4a99aa904.png">
