### PR TITLE
Stripped Table

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -240,7 +240,7 @@ table.data > tbody > tr > td.ic-dataset img { width: 20px; }
 #highlights .tool p                         { margin-bottom: 20px; }
 #highlights .tool .btn                      { margin-bottom: 20px; padding: 10px 20px; font-weight: 600; }
 #highlights .tool .btn:hover                { color: #333; }
-#highlights .tab-content tr:nth-child(2)    { background-color: rgba(0,0,0,0.4); }
+#highlights .tab-content tr:nth-child(even) { background-color: rgba(0,0,0,0.4); }
 
 /*********************************
     ABOUT SECTION STYLES


### PR DESCRIPTION
Fixed bug that would display the landing page data table rows background inconsistently

## Before

![screen shot 2016-01-29 at 12 36 43](https://cloud.githubusercontent.com/assets/1383865/12684560/2d7773fa-c685-11e5-8c13-c1f3c1e2a777.png)

## After

![screen shot 2016-01-29 at 12 36 58](https://cloud.githubusercontent.com/assets/1383865/12684562/31b6387a-c685-11e5-9037-dcee503dec04.png)
