### PR TITLE
Typo Fix

### DIFF
--- a/public/less/style.less
+++ b/public/less/style.less
@@ -299,7 +299,7 @@ section                                     { margin-bottom: 30px; }
 .tag-icon.tag-cultura-y-turismo,
 .tag-icon.tag-culture                       { background-image: url(../img/ic-cultura-y-turismo.png); }
 .tag-icon.tag-desarrollo-sostenible,
-.tag-icon.tag-development                   { background-image: url(../img/ic-desarollo-sostenible.png); }
+.tag-icon.tag-development                   { background-image: url(../img/ic-desarrollo-sostenible.png); }
 .tag-icon.tag-economia,
 .tag-icon.tag-economy                       { background-image: url(../img/ic-economia.png); }
 .tag-icon.tag-educacion,


### PR DESCRIPTION
Fixed type that prevent the development tag icon from being displayed

Closes #842 

<img width="1108" alt="screen shot 2016-06-13 at 14 21 20" src="https://cloud.githubusercontent.com/assets/1383865/16020179/498da746-3172-11e6-9f10-e0a0865751b2.png">