### PR TITLE
Tool Title

### DIFF
--- a/public/less/style.less
+++ b/public/less/style.less
@@ -355,7 +355,7 @@ div.page-404 img                            { width: 50%; }
 .post-info .read-more:after                 { content: ""; display: inline-block; width: 0; height: 0; margin-left: 5px; border-top: 6px solid transparent; border-bottom: 6px solid transparent; border-left: 6px solid #0c9; position: relative; top: 2px; }
 .tool-item .tag-icon                        { float: left; }
 .tool-item .tool-content                    { width: ~"calc(100% - 45px)"; float: right; }
-.tool-item .inner h3                        { margin-top: 0; height: 30px; line-height: 30px; }
+.tool-item .inner h3                        { margin-top: 0; line-height: 30px; }
 .tool-item .inner p                         { margin-bottom: 5px; }
 .tool-item .inner .category                 { margin-bottom: 10px; }
 .post-info .category                        { margin-bottom: 0; }


### PR DESCRIPTION
Fixed bug that would cause a long tool title to overlap the category

Closes #900 

<img width="1189" alt="screen shot 2016-06-20 at 13 09 02" src="https://cloud.githubusercontent.com/assets/1383865/16205178/35a3514c-36e8-11e6-81e3-ad35a2f0e493.png">