### PR TITLE
Tools Title

### DIFF
--- a/views/partials/includes/tool.jade
+++ b/views/partials/includes/tool.jade
@@ -3,8 +3,8 @@
         span( class="tag-icon tag-{{ post.tag.slug }}" )
     .tool-content
         h3
-            a( href="{{ post.external_link }}" alt="{{ post.name }}" target="_blank" ng-if="post.external_link" ) {{ post.name | limitTo:46 }}
-            a( ui-sref="front.post({ section : post.section.slug, category : post.category.slug, tag : post.tag.slug, post : post.slug })" alt="{{ post.name }}" ng-if="!post.external_link" ) {{ post.name | limitTo:46 }}
+            a( href="{{ post.external_link }}" alt="{{ post.name }}" target="_blank" ng-if="post.external_link" ) {{ post.name }}
+            a( ui-sref="front.post({ section : post.section.slug, category : post.category.slug, tag : post.tag.slug, post : post.slug })" alt="{{ post.name }}" ng-if="!post.external_link" ) {{ post.name }}
         p.category
             a( ui-sref="front.section({ section : post.section.slug, category : post.category.slug })" alt="{{ post.category.name }}" ) {{ post.category.name }}
         p.author {{ post.author }}


### PR DESCRIPTION
Removed functionality that limited the tools title length

Closes #912 

<img width="1187" alt="screen shot 2016-06-20 at 14 34 42" src="https://cloud.githubusercontent.com/assets/1383865/16207703/349d8324-36f4-11e6-872f-68c5fd42a5e0.png">