### PR TITLE
Revert "fix: Change position tabs in data section"

### DIFF
--- a/public/js/data/DataLoadCtrl.js
+++ b/public/js/data/DataLoadCtrl.js
@@ -11,13 +11,7 @@ define( function () {
             ],
             query       = function ( type ) {
                 switch( type ) {
-
                     case 0 :
-                        var q       = ( $stateParams.category ) ? 'tags:' + $stateParams.category : '';
-
-                        $scope.datasets = CkanService.datasets( q, 5, 'dcat_modified desc' );
-                        break;
-                    case 1 :
                         $scope.datasets     = Array();
                         Datasets.query({
                             order       : 'DESC',
@@ -42,6 +36,11 @@ define( function () {
                                 });
                             }
                         });
+                        break;
+                    case 1 :
+                        var q       = ( $stateParams.category ) ? 'tags:' + $stateParams.category : '';
+
+                        $scope.datasets = CkanService.datasets( q, 5, 'dcat_modified desc' );
                         break;
                     case 2 :
                         $scope.datasets     = Array();

--- a/views/partials/data/table.jade
+++ b/views/partials/data/table.jade
@@ -1,13 +1,13 @@
 .container-fluid
     .row
         .col-md-12
-            h2
+            h2 
                 a( href="//datos.gob.mx/busca" target="_self" ) Datos
             ul.data-list.row
-                li.col-md-4.col-xs-12.col-sm-12.active( ng-click="load( $event, 0 )" )
-                    span Recientes
-                li.col-md-4.col-xs-12.col-sm-12( ng-click="load( $event, 1 )" )
+                li.col-md-4.col-xs-12.col-sm-12.active( ng-click="load( $event, 0 )" ) 
                     span Recomendados
+                li.col-md-4.col-xs-12.col-sm-12( ng-click="load( $event, 1 )" ) 
+                    span Recientes
                 li.col-md-4.col-xs-12.col-sm-12( ng-click="load( $event, 2 )" )
                     span Más descargados
             .data-table


### PR DESCRIPTION
This reverts commit 8c6263fec85521b8d85636fcb6c8731987e29f47.

Se revierte el cambio en el que sale primero los recientes y luego los destacados

@KielRodriguez me pidieron cambiar el orden de las pestañas y encontré el commit donde las habías cambiado y este commit lo revierte.

Lo hice haciendo `git revert 8c6263fec85521b8d85636fcb6c8731987e29f47`