### PR TITLE
Add reset-footer.css file to fix footer style

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -18,6 +18,7 @@ html
         // endbower
 
         link( rel="stylesheet" href="css/style.css" )
+        link( rel="stylesheet", href=process.env.CDN_URL + 'dgm-style/reset-footer.css')
 
         if settings.env == 'development'
             script( src="http://localhost:35729/livereload.js?snipver=1" )


### PR DESCRIPTION
Add reset-footer.css file to fix footer style

## How to test?
Review footer style shouldn't show space  to the end