### PR TITLE
fixing the name of post which it's over categories's icon

### DIFF
--- a/public/less/sec-style.less
+++ b/public/less/sec-style.less
@@ -3,6 +3,11 @@
 // en los estilos estandarizados
 // ----------------------------------------------------------
 
+.size_class  {
+  min-height: 50px !important;
+  border: 0px;
+  -moz-force-broken-image-icon: 0;
+ }
 .right-side-menu {
   margin-top: 30px;
 }

--- a/views/partials/includes/post.jade
+++ b/views/partials/includes/post.jade
@@ -1,6 +1,6 @@
 .inner
-  a( ui-sref="front.post({ section : post.section.slug, category : post.category.slug, tag : post.tag.slug, post : post.slug })" alt="{{ post.name }}" ng-if="!post.featured" )
-    img( ng-src="{{ post.grid_photo.path }}")
+  a.size_class( ui-sref="front.post({ section : post.section.slug, category : post.category.slug, tag : post.tag.slug, post : post.slug })" alt="{{ post.name }}" ng-if="!post.featured" )
+   img( ng-src="{{ post.grid_photo.path }}" alt='')
   a.hidden-xs.hidden-sm( ui-sref="front.post({ section : post.section.slug, category : post.category.slug, tag : post.tag.slug, post : post.slug })" alt="{{ post.name }}" ng-if="post.featured" )
     img( ng-src="{{ post.cover_photo.path }}")
   a.hidden-md.hidden-lg( ui-sref="front.post({ section : post.section.slug, category : post.category.slug, tag : post.tag.slug, post : post.slug })" alt="{{ post.name }}" ng-if="post.featured" )


### PR DESCRIPTION
## Changed: Fixing the name of post which it's over categories's icon.

### Modify:
M: public/less/sec-style.less
M: views/partials/includes/post.jade

### Steps:

1)  Download this PR.
2) Start up your local environment.

### How to test:

1) In the  host:puerto/blog  watch the name of any Post that does not have image and the Post it is not over the icon's category in Fireforex.
